### PR TITLE
Fixes PIO build issues and added PIO registry metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ CMakeFiles
 CMakeScripts
 cmake_install.cmake
 install_manifest.txt
+
+# vscode
+.vscode

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ CANARY_ARGS = -DJSON11_ENABLE_DR1467_CANARY=$(JSON11_ENABLE_DR1467_CANARY)
 endif
 
 test: json11.cpp json11.hpp test.cpp
-	$(CXX) $(CANARY_ARGS) -O -std=c++11 json11.cpp test.cpp -o test -fno-rtti -fno-exceptions
+	$(CXX) $(CANARY_ARGS) -DJSON11_TEST_STANDALONE_CONFIG -O -std=c++11 json11.cpp test.cpp -o test -fno-rtti -fno-exceptions
 
 clean:
 	if [ -e test ]; then rm test; fi

--- a/library.json
+++ b/library.json
@@ -1,0 +1,31 @@
+{
+  "name": "json11",
+  "version": "1.0.1",
+  "description": "A microscopic JSON library for C++11",
+  "keywords": "c++ json",
+  "repository":
+  {
+    "type": "git",
+    "url": "https://github.com/meshtastic/json11.git"
+  },
+  "authors":
+  [
+    {
+      "name": "Dropbox Inc.",
+      "email": "info@dropbox.com",
+      "url": "https://www.dropbox.com/"
+    },
+    {
+      "name": "Michael Kleinhenz",
+      "email": "michael@kleinhenz.net",
+      "url": "https://github.com/michaelkleinhenz",
+      "maintainer": true
+    }
+  ],
+  "license": "MIT",
+  "homepage": "https://github.com/meshtastic/json11",
+  "dependencies": {
+  },
+  "frameworks": "*",
+  "platforms": "*"
+}

--- a/test.cpp
+++ b/test.cpp
@@ -1,11 +1,12 @@
 /*
- * Define JSON11_TEST_CUSTOM_CONFIG to 1 if you want to build this tester into
- * your own unit-test framework rather than a stand-alone program.  By setting
+ * Define JSON11_TEST_STANDALONE_CONFIG to 1 if you want to build this tester into
+ * stand-alone program rather than a your own unit-test framework. By setting
  * The values of the variables included below, you can insert your own custom
  * code into this file as it builds, in order to make it into a test case for
  * your favorite framework.
  */
-#if !JSON11_TEST_CUSTOM_CONFIG
+
+#if JSON11_TEST_STANDALONE_CONFIG
 #define JSON11_TEST_CPP_PREFIX_CODE
 #define JSON11_TEST_CPP_SUFFIX_CODE
 #define JSON11_TEST_STANDALONE_MAIN 1
@@ -14,7 +15,7 @@
 #ifdef NDEBUG
 #undef NDEBUG//at now assert will work even in Release build
 #endif
-#endif // JSON11_TEST_CUSTOM_CONFIG
+#endif // JSON11_TEST_STANDALONE_CONFIG
 
 /*
  * Enable or disable code which demonstrates the behavior change in Xcode 7 / Clang 3.7,


### PR DESCRIPTION
This fixes the native build issue with PIO and Meshtastic by reversing the logic on the test suite. It also adds metadata for PIO registry deployment.